### PR TITLE
frontend: fix sidenav overflow style

### DIFF
--- a/admin/sidenav/sidenav.component.scss
+++ b/admin/sidenav/sidenav.component.scss
@@ -1,0 +1,27 @@
+.clr-vertical-nav {
+  $scroll-bar-width: 8px;
+  $scroll-margin-width: 2px;
+  $scrollbar-bg: #373b41;
+  $scrollbar-color: #adbbc4;
+
+  &.has-nav-groups.has-icons.is-collapsed {
+    width: 2.3rem;
+  }
+  ::ng-deep {
+    .nav-content {
+      &::-webkit-scrollbar {
+        width: $scroll-bar-width;
+      }
+      &::-webkit-scrollbar-track {
+        background: $scrollbar-bg;
+      }
+      &::-webkit-scrollbar-thumb {
+        border-radius: ($scroll-bar-width + $scroll-margin-width) / 2;
+        width: $scroll-bar-width;
+        background-color: $scrollbar-color;
+        background-clip: padding-box;
+        border: $scroll-margin-width solid transparent;
+      }
+    }
+  }
+}

--- a/admin/sidenav/sidenav.component.ts
+++ b/admin/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthService} from "../../../src/app/shared/auth/auth.service";
+import {AuthService} from '../../../src/app/shared/auth/auth.service';
 
 @Component({
   selector: 'wayne-sidenav',


### PR DESCRIPTION
左侧导航栏在 mac chrome 下样式有问题

修复之前
![image](https://user-images.githubusercontent.com/17901361/49218999-f0b55280-f40c-11e8-91d6-7a9d93de3bf6.png)


修复之后
![image](https://user-images.githubusercontent.com/17901361/49218976-dc715580-f40c-11e8-91d2-fc7118907d6a.png)
